### PR TITLE
[AGENT PROVISION] AWS IAM Role - EC2 Least Privilege Access

### DIFF
--- a/terraform/iam-role-ec2-least-privilege/README.md
+++ b/terraform/iam-role-ec2-least-privilege/README.md
@@ -1,0 +1,93 @@
+# AWS IAM Role - EC2 Least Privilege Access
+
+This Terraform configuration creates an AWS IAM role with least privilege access to EC2 resources.
+
+## Features
+
+- **Least Privilege Access**: Only grants necessary EC2 permissions
+- **Read-Only Operations**: Full describe, get, and list capabilities for EC2 resources
+- **Limited Write Operations**: Restricted to starting, stopping, and rebooting instances
+- **Tag Management**: Ability to manage tags on EC2 instances and volumes
+- **Instance Profile**: Includes an IAM instance profile for EC2 attachment
+- **Regional Restrictions**: Permissions are scoped to the specified AWS region
+
+## Permissions Included
+
+### Read-Only Permissions
+- `ec2:Describe*` - Describe all EC2 resources
+- `ec2:Get*` - Get information about EC2 resources
+- `ec2:List*` - List EC2 resources
+
+### Instance Management
+- `ec2:StartInstances` - Start EC2 instances
+- `ec2:StopInstances` - Stop EC2 instances
+- `ec2:RebootInstances` - Reboot EC2 instances
+
+### Tag Management
+- `ec2:CreateTags` - Create tags on instances and volumes
+- `ec2:DeleteTags` - Delete tags from instances and volumes
+
+## Usage
+
+### Prerequisites
+- Terraform >= 1.0
+- AWS credentials configured
+- Appropriate AWS permissions to create IAM resources
+
+### Deployment
+
+1. **Initialize Terraform**
+   ```bash
+   terraform init
+   ```
+
+2. **Review the Plan**
+   ```bash
+   terraform plan
+   ```
+
+3. **Apply Configuration**
+   ```bash
+   terraform apply
+   ```
+
+### Configuration
+
+Copy the example variables file and customize:
+```bash
+cp terraform.tfvars.example terraform.tfvars
+```
+
+Edit `terraform.tfvars` with your desired values:
+- `aws_region`: Target AWS region
+- `role_name`: Name for the IAM role
+- `tags`: Additional resource tags
+
+## Outputs
+
+After deployment, the following outputs are available:
+
+- `role_arn`: ARN of the IAM role
+- `role_name`: Name of the IAM role
+- `role_id`: Unique ID of the IAM role
+- `policy_arn`: ARN of the IAM policy
+- `instance_profile_arn`: ARN of the instance profile
+- `instance_profile_name`: Name of the instance profile
+
+## Security Considerations
+
+- Permissions are scoped to the specified AWS region
+- No permissions for creating, terminating, or modifying EC2 instances
+- No access to sensitive operations like key pair management
+- Trust relationship limited to EC2 service principal only
+
+## Cleanup
+
+To remove all resources:
+```bash
+terraform destroy
+```
+
+## License
+
+This code is provided as-is for infrastructure provisioning purposes.

--- a/terraform/iam-role-ec2-least-privilege/main.tf
+++ b/terraform/iam-role-ec2-least-privilege/main.tf
@@ -1,0 +1,127 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# IAM role with EC2 trust relationship
+resource "aws_iam_role" "ec2_role" {
+  name               = var.role_name
+  description        = "IAM role with least privilege access to EC2 resources"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume_role.json
+
+  tags = merge(
+    var.tags,
+    {
+      Name        = var.role_name
+      ManagedBy   = "Terraform"
+      Purpose     = "EC2LeastPrivilege"
+    }
+  )
+}
+
+# Trust relationship policy for EC2 service
+data "aws_iam_policy_document" "ec2_assume_role" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+# IAM policy with least privilege EC2 permissions
+resource "aws_iam_policy" "ec2_least_privilege" {
+  name        = "${var.role_name}-policy"
+  description = "Least privilege policy for EC2 operations"
+  policy      = data.aws_iam_policy_document.ec2_least_privilege.json
+
+  tags = merge(
+    var.tags,
+    {
+      Name      = "${var.role_name}-policy"
+      ManagedBy = "Terraform"
+    }
+  )
+}
+
+# EC2 least privilege policy document
+data "aws_iam_policy_document" "ec2_least_privilege" {
+  # Read-only EC2 permissions
+  statement {
+    sid    = "EC2ReadOnly"
+    effect = "Allow"
+    actions = [
+      "ec2:Describe*",
+      "ec2:Get*",
+      "ec2:List*"
+    ]
+    resources = ["*"]
+  }
+
+  # Instance management permissions (restricted)
+  statement {
+    sid    = "EC2InstanceManagement"
+    effect = "Allow"
+    actions = [
+      "ec2:StartInstances",
+      "ec2:StopInstances",
+      "ec2:RebootInstances"
+    ]
+    resources = [
+      "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestedRegion"
+      values   = [var.aws_region]
+    }
+  }
+
+  # Tag management for EC2 resources
+  statement {
+    sid    = "EC2TagManagement"
+    effect = "Allow"
+    actions = [
+      "ec2:CreateTags",
+      "ec2:DeleteTags"
+    ]
+    resources = [
+      "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*",
+      "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:volume/*"
+    ]
+  }
+}
+
+# Attach policy to role
+resource "aws_iam_role_policy_attachment" "ec2_policy_attachment" {
+  role       = aws_iam_role.ec2_role.name
+  policy_arn = aws_iam_policy.ec2_least_privilege.arn
+}
+
+# Instance profile for EC2 instances
+resource "aws_iam_instance_profile" "ec2_profile" {
+  name = "${var.role_name}-profile"
+  role = aws_iam_role.ec2_role.name
+
+  tags = merge(
+    var.tags,
+    {
+      Name      = "${var.role_name}-profile"
+      ManagedBy = "Terraform"
+    }
+  )
+}
+
+# Data source for current AWS account
+data "aws_caller_identity" "current" {}

--- a/terraform/iam-role-ec2-least-privilege/outputs.tf
+++ b/terraform/iam-role-ec2-least-privilege/outputs.tf
@@ -1,0 +1,29 @@
+output "role_arn" {
+  description = "ARN of the IAM role"
+  value       = aws_iam_role.ec2_role.arn
+}
+
+output "role_name" {
+  description = "Name of the IAM role"
+  value       = aws_iam_role.ec2_role.name
+}
+
+output "role_id" {
+  description = "Unique ID of the IAM role"
+  value       = aws_iam_role.ec2_role.id
+}
+
+output "policy_arn" {
+  description = "ARN of the IAM policy"
+  value       = aws_iam_policy.ec2_least_privilege.arn
+}
+
+output "instance_profile_arn" {
+  description = "ARN of the instance profile"
+  value       = aws_iam_instance_profile.ec2_profile.arn
+}
+
+output "instance_profile_name" {
+  description = "Name of the instance profile"
+  value       = aws_iam_instance_profile.ec2_profile.name
+}

--- a/terraform/iam-role-ec2-least-privilege/terraform.tfvars.example
+++ b/terraform/iam-role-ec2-least-privilege/terraform.tfvars.example
@@ -1,0 +1,11 @@
+# Example Terraform variables file
+# Copy this file to terraform.tfvars and customize as needed
+
+aws_region = "us-east-1"
+role_name  = "ec2-least-privilege-role"
+
+tags = {
+  Environment = "production"
+  Project     = "infrastructure"
+  Team        = "platform"
+}

--- a/terraform/iam-role-ec2-least-privilege/variables.tf
+++ b/terraform/iam-role-ec2-least-privilege/variables.tf
@@ -1,0 +1,22 @@
+variable "aws_region" {
+  description = "AWS region where resources will be created"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "role_name" {
+  description = "Name of the IAM role"
+  type        = string
+  default     = "ec2-least-privilege-role"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-_]+$", var.role_name))
+    error_message = "Role name must contain only alphanumeric characters, hyphens, and underscores."
+  }
+}
+
+variable "tags" {
+  description = "Additional tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Pull Request Summary

This PR implements an AWS IAM role with least privilege access to EC2 resources only.

### Related Issue
Closes #5

### Changes Made
- ✅ Created IAM role with EC2 service trust relationship
- ✅ Implemented least privilege IAM policy:
  - Read-only operations: Describe*, Get*, List* for all EC2 resources
  - Limited write operations: Start/Stop/Reboot instances only
  - Tag management: Create/Delete tags on instances and volumes
- ✅ Added IAM instance profile for EC2 attachment
- ✅ Regional scoping for permissions
- ✅ Comprehensive documentation and examples
- ✅ Terraform configuration validated

### Files Added
- `terraform/iam-role-ec2-least-privilege/main.tf`
- `terraform/iam-role-ec2-least-privilege/variables.tf`
- `terraform/iam-role-ec2-least-privilege/outputs.tf`
- `terraform/iam-role-ec2-least-privilege/terraform.tfvars.example`
- `terraform/iam-role-ec2-least-privilege/README.md`

### Security Considerations
- Permissions follow AWS least privilege principle
- Trust relationship restricted to EC2 service only
- No permissions for instance creation, termination, or key pair management
- Regional restrictions enforced on write operations

### Testing
- ✅ Terraform init successful
- ✅ Terraform validate passed

---

@copilot run review-tf-design agent to review the changes