### PR TITLE
feat: Add IAM role with least privilege EC2 access

### DIFF
--- a/terraform/iam-role-ec2-least-privilege/README.md
+++ b/terraform/iam-role-ec2-least-privilege/README.md
@@ -1,0 +1,159 @@
+# AWS IAM Role with Least Privilege EC2 Access
+
+This Terraform configuration creates an AWS IAM role with least privilege access to EC2 resources, following AWS security best practices.
+
+## Features
+
+- **Least Privilege Design**: Grants only the minimum permissions required for EC2 operations
+- **Read-Only Access**: Includes EC2 describe, get, and list operations
+- **Conditional Operations**: Instance start/stop/reboot limited to resources tagged with `ManagedBy=Terraform`
+- **CloudWatch Integration**: Basic CloudWatch metrics access for EC2 monitoring
+- **EC2 Trust Policy**: Allows EC2 service to assume the role
+- **Instance Profile**: Includes instance profile for attaching role to EC2 instances
+
+## Resources Created
+
+1. **IAM Role** (`aws_iam_role.ec2_least_privilege`)
+   - Trust policy allowing EC2 service assumption
+   - Tagged with environment and management information
+
+2. **IAM Policy** (`aws_iam_policy.ec2_least_privilege`)
+   - Read-only EC2 permissions (Describe*, Get*, List*)
+   - Conditional write permissions (Start/Stop/Reboot) on tagged resources
+   - CloudWatch metrics access
+
+3. **IAM Role Policy Attachment** (`aws_iam_role_policy_attachment.ec2_least_privilege`)
+   - Attaches the policy to the role
+
+4. **IAM Instance Profile** (`aws_iam_instance_profile.ec2_least_privilege`)
+   - Enables role attachment to EC2 instances
+
+## Permissions Granted
+
+### Read-Only Permissions
+- `ec2:Describe*` - Describe EC2 resources
+- `ec2:Get*` - Get EC2 resource information
+- `ec2:List*` - List EC2 resources
+
+### Conditional Write Permissions
+- `ec2:StartInstances` - Start EC2 instances (only on tagged resources)
+- `ec2:StopInstances` - Stop EC2 instances (only on tagged resources)
+- `ec2:RebootInstances` - Reboot EC2 instances (only on tagged resources)
+
+**Condition**: Resources must have tag `ManagedBy=Terraform`
+
+### Monitoring Permissions
+- `cloudwatch:GetMetricStatistics` - Retrieve CloudWatch metrics
+- `cloudwatch:ListMetrics` - List available metrics
+
+## Usage
+
+### Prerequisites
+- AWS CLI configured with appropriate credentials
+- Terraform >= 1.0 installed
+- AWS provider ~> 5.0
+
+### Basic Deployment
+
+```bash
+# Initialize Terraform
+terraform init
+
+# Review the execution plan
+terraform plan
+
+# Apply the configuration
+terraform apply
+```
+
+### Custom Configuration
+
+Create a `terraform.tfvars` file:
+
+```hcl
+aws_region  = "us-west-2"
+role_name   = "my-ec2-role"
+environment = "prod"
+
+tags = {
+  Project = "MyProject"
+  Owner   = "DevOps Team"
+}
+```
+
+### Using the Role with EC2 Instances
+
+```hcl
+resource "aws_instance" "example" {
+  ami                  = "ami-xxxxx"
+  instance_type        = "t3.micro"
+  iam_instance_profile = module.iam_role.instance_profile_name
+
+  tags = {
+    ManagedBy = "Terraform"  # Required for start/stop/reboot permissions
+  }
+}
+```
+
+## Variables
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| aws_region | AWS region where resources will be created | string | us-east-1 | no |
+| role_name | Name of the IAM role | string | ec2-least-privilege-role | no |
+| environment | Environment name (dev, staging, prod) | string | dev | no |
+| tags | Additional tags to apply to resources | map(string) | {} | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| role_arn | ARN of the IAM role |
+| role_name | Name of the IAM role |
+| role_id | ID of the IAM role |
+| policy_arn | ARN of the IAM policy |
+| policy_name | Name of the IAM policy |
+| instance_profile_arn | ARN of the instance profile |
+| instance_profile_name | Name of the instance profile |
+
+## Security Best Practices
+
+1. **Least Privilege**: Only grants minimum required permissions
+2. **Resource Tagging**: Write operations limited to tagged resources
+3. **Service-Specific Trust**: Only EC2 service can assume the role
+4. **No Wildcard Actions**: Specific action patterns used where possible
+5. **Read-Heavy Design**: Most permissions are read-only
+
+## Testing
+
+Validate the configuration:
+
+```bash
+# Format code
+terraform fmt
+
+# Validate syntax
+terraform validate
+
+# Security scan (requires tfsec)
+tfsec .
+```
+
+## Cleanup
+
+To remove all created resources:
+
+```bash
+terraform destroy
+```
+
+## Notes
+
+- This role is designed for EC2 instances that need basic self-management capabilities
+- Write operations (start/stop/reboot) require the `ManagedBy=Terraform` tag
+- Consider adding additional restrictions based on your specific use case
+- Review and audit permissions regularly
+
+## License
+
+This configuration is provided as-is for educational and operational purposes.

--- a/terraform/iam-role-ec2-least-privilege/main.tf
+++ b/terraform/iam-role-ec2-least-privilege/main.tf
@@ -1,0 +1,125 @@
+# IAM Role with Least Privilege Access to EC2 Resources
+# This configuration creates an IAM role with minimal permissions for EC2 operations
+
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# IAM Role for EC2 with least privilege
+resource "aws_iam_role" "ec2_least_privilege" {
+  name               = var.role_name
+  description        = "IAM role with least privilege access to EC2 resources"
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
+
+  tags = merge(
+    var.tags,
+    {
+      Name        = var.role_name
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    }
+  )
+}
+
+# Trust policy - allows EC2 service to assume this role
+data "aws_iam_policy_document" "assume_role_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+# Least privilege policy for EC2 - read-only and basic instance operations
+data "aws_iam_policy_document" "ec2_least_privilege" {
+  # Allow read-only EC2 operations
+  statement {
+    sid    = "EC2ReadOnly"
+    effect = "Allow"
+    actions = [
+      "ec2:Describe*",
+      "ec2:Get*",
+      "ec2:List*"
+    ]
+    resources = ["*"]
+  }
+
+  # Allow specific EC2 operations on tagged resources only
+  statement {
+    sid    = "EC2InstanceOperations"
+    effect = "Allow"
+    actions = [
+      "ec2:StartInstances",
+      "ec2:StopInstances",
+      "ec2:RebootInstances"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "ec2:ResourceTag/ManagedBy"
+      values   = ["Terraform"]
+    }
+  }
+
+  # Allow CloudWatch metrics for EC2 monitoring
+  statement {
+    sid    = "CloudWatchMetrics"
+    effect = "Allow"
+    actions = [
+      "cloudwatch:GetMetricStatistics",
+      "cloudwatch:ListMetrics"
+    ]
+    resources = ["*"]
+  }
+}
+
+# Create and attach the least privilege policy
+resource "aws_iam_policy" "ec2_least_privilege" {
+  name        = "${var.role_name}-policy"
+  description = "Least privilege policy for EC2 operations"
+  policy      = data.aws_iam_policy_document.ec2_least_privilege.json
+
+  tags = merge(
+    var.tags,
+    {
+      Name        = "${var.role_name}-policy"
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    }
+  )
+}
+
+# Attach the policy to the role
+resource "aws_iam_role_policy_attachment" "ec2_least_privilege" {
+  role       = aws_iam_role.ec2_least_privilege.name
+  policy_arn = aws_iam_policy.ec2_least_privilege.arn
+}
+
+# Instance profile for attaching the role to EC2 instances
+resource "aws_iam_instance_profile" "ec2_least_privilege" {
+  name = "${var.role_name}-instance-profile"
+  role = aws_iam_role.ec2_least_privilege.name
+
+  tags = merge(
+    var.tags,
+    {
+      Name        = "${var.role_name}-instance-profile"
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    }
+  )
+}

--- a/terraform/iam-role-ec2-least-privilege/outputs.tf
+++ b/terraform/iam-role-ec2-least-privilege/outputs.tf
@@ -1,0 +1,34 @@
+output "role_arn" {
+  description = "ARN of the IAM role"
+  value       = aws_iam_role.ec2_least_privilege.arn
+}
+
+output "role_name" {
+  description = "Name of the IAM role"
+  value       = aws_iam_role.ec2_least_privilege.name
+}
+
+output "role_id" {
+  description = "ID of the IAM role"
+  value       = aws_iam_role.ec2_least_privilege.id
+}
+
+output "policy_arn" {
+  description = "ARN of the IAM policy"
+  value       = aws_iam_policy.ec2_least_privilege.arn
+}
+
+output "policy_name" {
+  description = "Name of the IAM policy"
+  value       = aws_iam_policy.ec2_least_privilege.name
+}
+
+output "instance_profile_arn" {
+  description = "ARN of the instance profile"
+  value       = aws_iam_instance_profile.ec2_least_privilege.arn
+}
+
+output "instance_profile_name" {
+  description = "Name of the instance profile"
+  value       = aws_iam_instance_profile.ec2_least_privilege.name
+}

--- a/terraform/iam-role-ec2-least-privilege/terraform.tfvars.example
+++ b/terraform/iam-role-ec2-least-privilege/terraform.tfvars.example
@@ -1,0 +1,13 @@
+# Example Terraform variables file
+# Copy this file to terraform.tfvars and customize for your environment
+
+aws_region  = "us-east-1"
+role_name   = "ec2-least-privilege-role"
+environment = "dev"
+
+tags = {
+  Project     = "Infrastructure"
+  Owner       = "DevOps"
+  CostCenter  = "Engineering"
+  Compliance  = "Required"
+}

--- a/terraform/iam-role-ec2-least-privilege/variables.tf
+++ b/terraform/iam-role-ec2-least-privilege/variables.tf
@@ -1,0 +1,33 @@
+variable "aws_region" {
+  description = "AWS region where resources will be created"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "role_name" {
+  description = "Name of the IAM role"
+  type        = string
+  default     = "ec2-least-privilege-role"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-_]+$", var.role_name))
+    error_message = "Role name must contain only alphanumeric characters, hyphens, and underscores."
+  }
+}
+
+variable "environment" {
+  description = "Environment name (e.g., dev, staging, prod)"
+  type        = string
+  default     = "dev"
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "Environment must be one of: dev, staging, prod."
+  }
+}
+
+variable "tags" {
+  description = "Additional tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Description
This PR adds Terraform configuration for an AWS IAM role with least privilege access to EC2 resources.

## Changes
- ✅ Created IAM role with EC2 service trust policy
- ✅ Implemented least privilege policy with read-only EC2 permissions (Describe*, Get*, List*)
- ✅ Added conditional write permissions (StartInstances, StopInstances, RebootInstances) limited to resources tagged with `ManagedBy=Terraform`
- ✅ Included CloudWatch metrics access for EC2 monitoring
- ✅ Created instance profile for attaching role to EC2 instances
- ✅ Added comprehensive documentation and usage examples

## Security Features
- **Least Privilege Design**: Only grants minimum required permissions
- **Resource Tagging**: Write operations limited to tagged resources (`ManagedBy=Terraform`)
- **Service-Specific Trust**: Only EC2 service can assume the role
- **Read-Heavy Design**: Most permissions are read-only

## Files Added
- `terraform/iam-role-ec2-least-privilege/main.tf` - Main Terraform configuration
- `terraform/iam-role-ec2-least-privilege/variables.tf` - Input variables
- `terraform/iam-role-ec2-least-privilege/outputs.tf` - Output values
- `terraform/iam-role-ec2-least-privilege/README.md` - Documentation
- `terraform/iam-role-ec2-least-privilege/terraform.tfvars.example` - Example variables

## Testing
- ✅ Terraform fmt passed
- ✅ Terraform init successful
- ✅ Terraform validate passed

## Related Issue
Closes #7

---
**Note**: This PR requires review by the review-tf-design agent.